### PR TITLE
Updated TEMPORARY_FONT_DIR for Linux compatability

### DIFF
--- a/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/ObfuscatedFontPart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/ObfuscatedFontPart.java
@@ -50,7 +50,7 @@ public class ObfuscatedFontPart extends BinaryPart {
     	// docx4all already creates a dir; no point creating a second 
 
     /** font cache file path */
-    private static final String TEMPORARY_FONT_DIR = "temporary embedded fonts";
+    private static final String TEMPORARY_FONT_DIR = "temporary_embedded_fonts";
 	
     private static File tmpFontDir = null; 
     


### PR DESCRIPTION
The spaces in the TEMPORARY_FONT_DIR causes issues in Linux systems. Replaced spaces with underlines for simplicity.